### PR TITLE
Fix permission error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ WORKDIR /app
 
 COPY . .
 
+RUN go build -v -o main .
+
 # Create a non root group and user
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 # Switch to the non root new user
 USER appuser
-
-RUN go build -o main .
 
 FROM alpine:3.14
 COPY --from=build /app/main /app/main


### PR DESCRIPTION
Switch build order to run as root before running the app as user. Related error:

go build main.go: copying /tmp/go-build1888114667/b001/exe/a.out: open main: permission denied